### PR TITLE
Fix ingress

### DIFF
--- a/kubernetes/ingress.yaml
+++ b/kubernetes/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: contoso-website

--- a/kubernetes/ingress.yaml
+++ b/kubernetes/ingress.yaml
@@ -9,7 +9,10 @@ spec:
     - host: contoso.!DNS!
       http:
         paths:
-          - backend:
-              serviceName: contoso-website
-              servicePort: http
-            path: /
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: contoso-website
+                port:
+                  name: http


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Encounter problem when learning AKS
https://learn.microsoft.com/en-us/training/modules/aks-application-autoscaling-native/1-introduction
* When I run the following cmd, the ingress can't be created because k8s have decrepted the apiVersion in kubernetes/ingress.yaml
https://kubernetes.io/docs/reference/using-api/deprecation-guide/
```
curl -L https://aka.ms/learn-scalability-init?v=$RANDOM | bash
```

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```sh
git clone https://github.com/crabasherard/mslearn-aks-application-scalability.git
cd mslearn-aks-application-scalability
git checkout fix_ingress
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
login azure cloud shell, then run the script (changed url of 'ingress.yaml' in kubernetes/deploy.sh)
```sh
#!/bin/bash
set -x
RESOURCE_NAME=learn-aks-scalability

echo "Creating cluster..."

az group create -n $RESOURCE_NAME -l eastus

az aks create -g $RESOURCE_NAME -n $RESOURCE_NAME --node-count=1 --generate-ssh-keys --enable-addons http_application_routing -s Standard_B2s

az aks get-credentials -g $RESOURCE_NAME -n $RESOURCE_NAME

echo "Gathering DNS name"

DNS_NAME=$(az aks show -g $RESOURCE_NAME -n $RESOURCE_NAME -o tsv --query addonProfiles.httpApplicationRouting.config.HTTPApplicationRoutingZoneName)

kubectl apply -f https://raw.githubusercontent.com/Azure-Samples/mslearn-aks-application-scalability/main/kubernetes/deployment.yaml
curl -L https://raw.githubusercontent.com/crabasherard/mslearn-aks-application-scalability/fix_ingress/kubernetes/ingress.yaml | sed 's+!DNS!+'"$DNS_NAME"'+g' | kubectl apply -f -
kubectl apply -f https://raw.githubusercontent.com/Azure-Samples/mslearn-aks-application-scalability/main/kubernetes/service.yaml

```

## What to Check
Verify that the following are valid
* ingress.yaml in main branch will throw error
![image](https://github.com/Azure-Samples/mslearn-aks-application-scalability/assets/131154777/7ec6a7b4-254b-49cf-915a-e953f906450d)

* after fix it will create ingress successfully
![image](https://github.com/Azure-Samples/mslearn-aks-application-scalability/assets/131154777/5206e232-a26d-429b-b3a2-aefd0b0c85c3)

## Other Information
<!-- Add any other helpful information that may be needed here. -->